### PR TITLE
Enable toggle for Always On Display

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -1933,10 +1933,10 @@
     <!-- Control whether the always on display mode is available. This should only be enabled on
          devices where the display has be tuned to be power efficient in DOZE and/or DOZE_SUSPEND
          states. -->
-    <bool name="config_dozeAlwaysOnDisplayAvailable">false</bool>
+    <bool name="config_dozeAlwaysOnDisplayAvailable">true</bool>
 
     <!-- Whether the display blanks itself when transitioning from a doze to a non-doze state -->
-    <bool name="config_displayBlanksAfterDoze">false</bool>
+    <bool name="config_displayBlanksAfterDoze">true</bool>
 
     <!-- True if the display hardware only has brightness buckets rather than a full range of
          backlight values -->


### PR DESCRIPTION
Set "config_dozeAlwaysOnDisplayAvailible" to "true", this enables the Always On Display toggle in the Display settings.
Set "config_displayBlanksAfterDoze" to "true", this will blank the screen when going from Ambient to Active to allow for consistent wakes from doze.